### PR TITLE
Fix byte-compile warning

### DIFF
--- a/eldoc-toml.el
+++ b/eldoc-toml.el
@@ -19,6 +19,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 
 (defun eldoc-toml--remove-comment (line)
   "Remove comment from end of LINE.


### PR DESCRIPTION
```
In end of data:
eldoc-toml.el:104:1:Warning: the function ‘string-trim’ is not known to be
    defined.
```